### PR TITLE
Fix for data structure concurrentHashmap which results in flaky-tests

### DIFF
--- a/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
+++ b/common-kafka/src/main/java/com/cerner/common/kafka/consumer/ProcessingKafkaConsumer.java
@@ -29,10 +29,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.Collections;
 
 /**
  * <p>
@@ -165,7 +166,7 @@ public class ProcessingKafkaConsumer<K, V> implements Closeable {
     /**
      * Maintains the state of all the partitions our consumer is assigned to
      */
-    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = new ConcurrentHashMap<>();
+    protected final Map<TopicPartition, ProcessingPartition<K, V>> partitions = Collections.synchronizedMap(new HashMap<>());
 
     /**
      * The partition to process from next


### PR DESCRIPTION
**Overview**:
Change `concurrentHashMap`  to  `Collections.synchronizedMap(new HashMap<>())` as it results in flaky tests for the test `com.cerner.common.kafka.consumer.ProcessingKafkaConsumerTest.nextRecord_fairProcessing`

**Command to reproduce**:
 `mvn -pl common-kafka edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cerner.common.kafka.consumer.ProcessingKafkaConsumerTest#nextRecord_fairProcessing`

**Result**:
The test fails on 4/5 iterations of the **Nondex** tool

**Reason**:
According to [concurrentHashMap documentation](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html), 
_"Because the elements of a ConcurrentHashMap are not ordered in any particular way, and may be processed in different orders in different parallel executions, the correctness of supplied functions should not depend on any ordering"_

**About the tool used to detect the Error**:
This test is detected as flaky by the **[NonDex](https://github.com/TestingResearchIllinois/NonDex)** tool developed by researchers at **UIUC**.
**Flaky tests** are tests in software development that produce inconsistent or unreliable results, which can lead to false non-deterministic outcomes of the test case, fixing them is important to both reliable testing and fixing vulnerabilities in the code.
